### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
       RELEASE_VERSION: "${{ github.event.release.tag_name }}"
       RELEASE_DESCRIPTION: "${{ github.event.release.name }}"
       RELEASE_TYPE: "release"
-      SUBAPP_PATHS: "supervisely"
+      SUBAPP_PATHS: "__ROOT_APP__"

--- a/supervisely/config.json
+++ b/supervisely/config.json
@@ -9,7 +9,7 @@
     "nn tools"
   ],
   "description": "Interactive Confusion matrix, mAP, ROC and more",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "supervisely/src/main.py",
   "gui_template": "supervisely/src/gui.html",

--- a/supervisely/config.json
+++ b/supervisely/config.json
@@ -9,8 +9,8 @@
     "nn tools"
   ],
   "description": "Interactive Confusion matrix, mAP, ROC and more",
-  "docker_image": "supervisely/base-py-sdk:6.73.531",
-  "instance_version": "6.15.40",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "instance_version": "6.15.60",
   "main_script": "supervisely/src/main.py",
   "gui_template": "supervisely/src/gui.html",
   "task_location": "workspace_tasks",

--- a/supervisely/dev_requirements.txt
+++ b/supervisely/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.55
+supervisely==6.73.564

--- a/supervisely/src/download_data.py
+++ b/supervisely/src/download_data.py
@@ -6,7 +6,7 @@ import globals as g
 import ui
 from src.bounding_box import BoundingBox as RepoBoundingBox, BBType
 # from supervisely.src.ui import metrics, overall_metrics, per_image_metrics, per_class_metrics
-# from supervisely_lib.app.widgets.confusion_matrix import ConfusionMatrix, plt2bb
+# from supervisely.app.widgets.confusion_matrix import ConfusionMatrix, plt2bb
 from utils import plt2bb
 from widgets.confusion_matrix import ConfusionMatrix
 

--- a/supervisely/src/ui/confusion_matrix.py
+++ b/supervisely/src/ui/confusion_matrix.py
@@ -6,7 +6,7 @@ from widgets.confusion_matrix import ConfusionMatrix
 from widgets.compare_gallery import CompareGallery
 from widgets.sly_table import SlyTable
 
-# from supervisely_lib.app.widgets.confusion_matrix import ConfusionMatrix
+# from supervisely.app.widgets.confusion_matrix import ConfusionMatrix
 
 confusion_matrix = ConfusionMatrix(api=g.api, task_id=g.task_id, v_model='data.slyConfusionMatrix')
 cm_image_table = None  # SlyTable(g.api, g.task_id, 'data.CMTableImages', g.image_columns)

--- a/supervisely/src/ui/per_class_metrics.py
+++ b/supervisely/src/ui/per_class_metrics.py
@@ -6,7 +6,7 @@ from widgets.sly_table import SlyTable
 from widgets.compare_gallery import CompareGallery
 import ui_utils
 
-# from supervisely_lib.app.widgets.sly_table import SlyTable
+# from supervisely.app.widgets.sly_table import SlyTable
 
 # gallery_per_class = CompareGallery(g.task_id, g.api, 'data.perClass', g.aggregated_meta)
 image_sly_table = None  # SlyTable(g.api, g.task_id, "data.perClassTable", g.image_columns)

--- a/supervisely/src/ui/per_image_metrics.py
+++ b/supervisely/src/ui/per_image_metrics.py
@@ -5,7 +5,7 @@ from widgets.compare_gallery import CompareGallery
 
 import metrics
 import ui_utils
-# from supervisely_lib.app.widgets.sly_table import SlyTable
+# from supervisely.app.widgets.sly_table import SlyTable
 
 image_sly_table = None  # SlyTable(g.api, g.task_id, "data.perImageTable", g.image_columns)
 gallery_per_image = None  # CompareGallery(g.task_id, g.api, 'data.perImage', g.aggregated_meta)


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
